### PR TITLE
Fix a bug and improved efficiency

### DIFF
--- a/src/main/java/net/techcable/event4j/HandlerList.java
+++ b/src/main/java/net/techcable/event4j/HandlerList.java
@@ -5,6 +5,9 @@ import lombok.*;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 @RequiredArgsConstructor
@@ -27,7 +30,8 @@ public class HandlerList<E, L> {
         bakedListeners = null;
     }
 
-    private final Set<RegisteredListener<E,L>> listenerSet = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    private final SortedSet<RegisteredListener<E,L>> listenerSet = Collections.synchronizedSortedSet(new TreeSet<>());
+    private final SortedSet<RegisteredListener> immutableSet = Collections.unmodifiableSortedSet((SortedSet<RegisteredListener>)(Object)listenerSet);
     private volatile RegisteredListener[] bakedListeners = null;
 
     @SuppressWarnings("unchecked")
@@ -41,15 +45,13 @@ public class HandlerList<E, L> {
         RegisteredListener[] baked;
         synchronized (this) {
             if ((baked = this.bakedListeners) == null) { // In case someone else baked while we were locking
-                baked = listenerSet.toArray(new RegisteredListener[listenerSet.size()]);
-                Arrays.sort(baked);
-                this.bakedListeners = baked;
+                this.bakedListeners = baked = listenerSet.toArray(new RegisteredListener[listenerSet.size()]);
             }
         }
         return baked;
     }
 
-    public Set<RegisteredListener> getListenerSet() {
-        return Collections.unmodifiableSet(listenerSet);
+    public SortedSet<RegisteredListener> getListenerSet() {
+        return immutableSet;
     }
 }

--- a/src/main/java/net/techcable/event4j/RegisteredListener.java
+++ b/src/main/java/net/techcable/event4j/RegisteredListener.java
@@ -69,6 +69,14 @@ public final class RegisteredListener<E, L> implements Comparable<RegisteredList
 
     @Override
     public int compareTo(RegisteredListener other) {
-        return Integer.compare(this.getPriority(), other.getPriority());
+        int t = Integer.compare(other.getPriority(), this.getPriority());
+        if (t != 0) {
+            return t;
+        }
+        t = Integer.compare(this.eventBus.hashCode(), other.eventBus.hashCode());
+        if (t != 0) {
+            return t;
+        }
+        return Integer.compare(this.hashCode(), other.hashCode());
     }
 }

--- a/src/test/java/net/techcable/event4j/EventTest.java
+++ b/src/test/java/net/techcable/event4j/EventTest.java
@@ -13,6 +13,7 @@ public class EventTest {
     @Before
     public void register() {
         this.testListener = new TestListener();
+        testListener.hasCalled = false;
         eventBus.register(testListener);
     }
 
@@ -34,6 +35,19 @@ public class EventTest {
     }
 
     public class TestListener {
+
+        boolean hasCalled;
+
+        @EventHandler(priority = EventPriority.HIGHEST)
+        public void callZero(TestEvent event) {
+            hasCalled = true;
+        }
+
+        @EventHandler(priority = EventPriority.LOWEST)
+        public void callOne(TestEvent event) {
+            assertTrue(hasCalled);
+        }
+
         @EventHandler
         public void onTest(TestEvent event) {
             EventTest.this.awesome = true; // We are awesome


### PR DESCRIPTION
1). There's a bug which the ordering of events are reversed, found out in the 1st commit.
2). I changed the `compareTo` method to fix the problem above.
3). I used `TreeSet` to replace a `Set`, which you do not need to sort the array when you insert or delete.

Table for time efficiency: (these are the only operations used in `HandlerList`)

|  | HashSet | TreeSet |
| --- | --- | --- |
| add | `O(N log(N))` * | `O(log(N))` |
| remove | `O(N log(N))` * | `O(log(N))` |
| iteration | `O(N+Capacity)` ** | `O(N)` |

*: The exact time is `O(1)+O(N log(N))`, `O(1)` is addition/removal, and `O(N log(N))` is efficiency of sorting, and in bad cases it would be `O(N^2)`.

*\* : That slow performance is referenced [here](https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html), right above the bold line of **Note that this implementation is not synchronized.**

> Iterating over this set requires time proportional to the sum of the HashSet instance's size (the number of elements) plus the "capacity" of the backing HashMap instance (the number of buckets). Thus, it's very important not to set the initial capacity too high (or the load factor too low) if iteration performance is important.
